### PR TITLE
add device selector, add type of release to versions, add dev version handling

### DIFF
--- a/web/flash/index.html
+++ b/web/flash/index.html
@@ -63,6 +63,7 @@
             <select id="version" class="bg-slate-700 text-slate-300 border border-sky-600 rounded-lg p-2 w-full">
               <!--<option selected value="xyz">v1.3.00</option>
               <option value="abc">v1.2.04</option>-->
+              <option value="downloading">downloading ...</option>
             </select>
           </div>
 
@@ -72,6 +73,7 @@
             <select id="channel" class="bg-slate-700 text-slate-300 border border-sky-600 rounded-lg p-2 w-full">
               <!--<option value="firmware/release-matek/rx-matek-mr24-30-g431kb-v1.3.00.hex">Matek mR24-30</option>
               <option value="firmware/release-matek/rx-matek-mr900-22-wle5cc-v1.3.00.hex">Matek mR900-22</option>-->
+              <option value="downloading">downloading ...</option>
             </select>
           </div>
 
@@ -144,6 +146,9 @@
         // Read the mlrs_firmware_urls.json to extract information on the versions
         const versions = getVersions()
         .then((versions) => {
+            var version_element = document.getElementById('version');
+            version_element.options.length = 0;
+        
             Object.keys(versions).forEach(key => {
                 //console.log(key);
                 //console.log(versions[key]);
@@ -151,10 +156,9 @@
                 const option = document.createElement('option');
                 option.textContent = versions[key].versionStr; //key;
                 option.value = versions[key].gitUrl;
-                document.getElementById('version').appendChild(option);
+                version_element.appendChild(option);
             });
 
-            var version_element = document.getElementById('version');
             version_element.selectedIndex = 0; // select first option
             version_element.dispatchEvent(new Event('change')); // throw a change event to update firmware list
         });
@@ -166,16 +170,6 @@
         .then((files) => {
             var channel_element = document.getElementById('channel');
             channel_element.options.length = 0;
-
-            if (files.length == 0) {
-                const option = document.createElement('option');
-                option.textContent = 'not available';
-                option.value = '';
-                option.setAttribute('data-accept-header', 'application/vnd.github.raw+json');
-                option.setAttribute('data-extension', '');
-                channel_element.appendChild(option);
-                return;
-            }
 
             files.forEach((f) => {
                 // Create a new option element

--- a/web/flash/index.html
+++ b/web/flash/index.html
@@ -48,8 +48,17 @@
           <p class="text-slate-300">Please connect your device via USB to the computer before proceeding.</p>
           <p class="text-slate-300">Select the firmware and click the button below. Then select DFU mode and follow the on-screen instructions.</p>
 
-          <!-- Version Dropdown -->
+          <!-- Device Class Dropdown -->
           <div class="py-6">
+            <label for="device" class="block text-slate-200 mb-2">Select Device Type:</label>
+            <select id="device" class="bg-slate-700 text-slate-300 border border-sky-600 rounded-lg p-2 w-full">
+              <!--<option selected value="xyz">v1.3.00</option>
+              <option value="abc">v1.2.04</option>-->
+            </select>
+          </div>
+
+          <!-- Version Dropdown -->
+          <div class="mb-4">
             <label for="version" class="block text-slate-200 mb-2">Select Firmware Version:</label>
             <select id="version" class="bg-slate-700 text-slate-300 border border-sky-600 rounded-lg p-2 w-full">
               <!--<option selected value="xyz">v1.3.00</option>
@@ -116,52 +125,87 @@
     </div> <!-- End class="container w-3/5" -->
 
     <script>
-      document.addEventListener("DOMContentLoaded", function(event) {
-          // read the mlrs_firmware_urls.json to extract information on the versions
-          const versions = getVersions()
-          .then((versions) => {
+
+    document.addEventListener("DOMContentLoaded", function(event) {
+        // Create the device option list
+        const devices = getDevices()
+        .then((devices) => {
+            Object.keys(devices).forEach(key => {
+                //console.log(key);
+                //console.log(devices[key]);
+                const option = document.createElement('option');
+                option.textContent = key;
+                option.value = devices[key];
+                document.getElementById('device').appendChild(option);
+            });
+        });
+        document.getElementById('device').selectedIndex = 0; // select first option
+
+        // Read the mlrs_firmware_urls.json to extract information on the versions
+        const versions = getVersions()
+        .then((versions) => {
             Object.keys(versions).forEach(key => {
-                    //console.log(key);
-                    //console.log(versions[key]);
-                    //console.log(versions[key].commit);
-                    const option = document.createElement('option');
-                    option.textContent = key;
-                    option.value = versions[key].gitUrl;
-                    document.getElementById('version').appendChild(option);
+                //console.log(key);
+                //console.log(versions[key]);
+                //console.log(versions[key].commit);
+                const option = document.createElement('option');
+                option.textContent = versions[key].versionStr; //key;
+                option.value = versions[key].gitUrl;
+                document.getElementById('version').appendChild(option);
             });
 
             var version_element = document.getElementById('version');
             version_element.selectedIndex = 0; // select first option
-            version_element.dispatchEvent(new Event('change'));
-          });
-      });
+            version_element.dispatchEvent(new Event('change')); // throw a change event to update firmware list
+        });
+    });
 
-      // Add an event listener to load the available firmware files, depening on the selected version
-      var version_element = document.getElementById('version');
-      version_element.addEventListener('change', function() {
-          //console.log('version changed');
-          //console.log(version_element.selectedIndex);
-          //console.log(version_element.value);
-          const files = getFilesFromTree(version_element.value)
-          .then((files) => {
+    // Helper function to load the available firmware files, depening on the selected device and version
+    function updateFirmwareList(device, url) {
+        const files = getFilesFromTree(device, url)
+        .then((files) => {
             var channel_element = document.getElementById('channel');
             channel_element.options.length = 0;
+
+            if (files.length == 0) {
+                const option = document.createElement('option');
+                option.textContent = 'not available';
+                option.value = '';
+                option.setAttribute('data-accept-header', 'application/vnd.github.raw+json');
+                option.setAttribute('data-extension', '');
+                channel_element.appendChild(option);
+                return;
+            }
+
             files.forEach((f) => {
-                    // Create a new option element
-                    const option = document.createElement('option');
+                // Create a new option element
+                const option = document.createElement('option');
 
-                    // Set the option's display text and value
-                    option.textContent = f.name; // Friendly name of the file
-                    option.value = f.downloadUrl; // URL to download the file
-                    option.setAttribute('data-accept-header', 'application/vnd.github.raw+json');
-                    option.setAttribute('data-extension', f.extension);
+                // Set the option's display text and value
+                option.textContent = f.name; // Friendly name of the file
+                option.value = f.downloadUrl; // URL to download the file
+                option.setAttribute('data-accept-header', 'application/vnd.github.raw+json');
+                option.setAttribute('data-extension', f.extension);
 
-                    // Append the option to the select element with the ID 'channel'
-                    channel_element.appendChild(option);
+                // Append the option to the select element with the ID 'channel'
+                channel_element.appendChild(option);
             });
-          });
-      });
+        });
+    }
 
+    // Add event listeners to load the available firmware files, depening on the selected device and version
+    var device_element = document.getElementById('device');
+    var version_element = document.getElementById('version');
+
+    device_element.addEventListener('change',  function() {
+        updateFirmwareList(device_element.value, version_element.value);
+    });
+
+    version_element.addEventListener('change', function() {
+        //console.log(device_element.selectedIndex);
+        //console.log(device_element.value);
+        updateFirmwareList(device_element.value, version_element.value);
+    });
 
     </script>
   </body>

--- a/web/flash/index.html
+++ b/web/flash/index.html
@@ -148,7 +148,7 @@
         .then((versions) => {
             var version_element = document.getElementById('version');
             version_element.options.length = 0;
-        
+
             Object.keys(versions).forEach(key => {
                 //console.log(key);
                 //console.log(versions[key]);

--- a/web/flash/mlrs.js
+++ b/web/flash/mlrs.js
@@ -1,8 +1,27 @@
 
+async function getDevices() {
+    try {
+        const data = { // this is easy enough to maintain by hand for the moment
+            'MatekSys' : 'matek',
+            'FrSky R9' : 'R9',
+            'FlySky FRM 303' : 'FRM303',
+            'Wio E5' : 'Wio-E5',
+            'E77 MBL Kit' : 'E77-MBLKit',
+            'Easysolder' : 'easysolder'
+        };
+
+        return data;
+    } catch (error) {
+        console.error('Error fetching data:', error);
+        return [];
+    }
+}
+
+
 async function getVersions() {
     try {
         // Fetch the JSON response from the URL
-        const url = 'https://raw.githubusercontent.com/olliw42/mLRS/main/tools/web/mlrs_firmware_urls.json'
+        const url = 'https://raw.githubusercontent.com/olliw42/mLRS/main/tools/web/mlrs_firmware_urls.json';
         const response = await fetch(url);
         const data = await response.json();
 
@@ -14,6 +33,17 @@ async function getVersions() {
             //console.log(key);
             //console.log(data[key]);
             //console.log(data[key].commit);
+            var patch = parseInt(key.split('.').pop());
+            //console.log(patch);
+            if (patch == 0) { // .00
+                data[key].versionStr = key + ' (release)';
+            } else if ((patch % 1) > 0) { // odd
+                data[key].versionStr = key + ' (dev)';
+            } else if ((patch % 1) == 0) { // even
+                data[key].versionStr = key + ' (pre-release)';
+            } else {
+                data[key].versionStr = key; // should not happen, play it safe
+            }
             data[key].gitUrl = 'https://api.github.com/repos/olliw42/mLRS/git/trees/' + data[key].commit + '?recursive=true';
         });
         //console.log('-----');
@@ -27,7 +57,7 @@ async function getVersions() {
 
 
 // Pass in a GitHub tree URL like https://api.github.com/repos/olliw42/mLRS/git/trees/f12d680?recursive=true
-async function getFilesFromTree(url) {
+async function getFilesFromTree(device, url) {
     try {
         // Fetch the JSON response from the URL
         const response = await fetch(url);
@@ -38,11 +68,13 @@ async function getFilesFromTree(url) {
         .filter(item => item.type == 'blob')
         .filter(item => item.path.indexOf('firmware/') == 0)
         .filter(item => !item.path.includes('-esp'))
+        .filter(item => item.path.includes('x-' + device)) // tx-device-xxx or rx-device-xxx
         .map(item => {
             return {
                 name: item.path.split('.')
                     .slice(0, -1).join('.')
-                    .replace(/^firmware\//, '').replace(/^release-/, '').replace(/^release/, 'stm32'),
+                    //.replace(/^firmware\//, '').replace(/^release-/, '').replace(/^release/, 'stm32'),
+                    .replace(/^firmware\//, '').replace(/^.*?\//, ''),
                 extension: item.path.split('.').slice(-1),
                 downloadUrl: item.url
             };

--- a/web/flash/mlrs.js
+++ b/web/flash/mlrs.js
@@ -80,6 +80,14 @@ async function getFilesFromTree(device, url) {
             };
         });
 
+        if (files.length == 0) {
+            files.push({
+                name: 'not available',
+                extension: '',
+                downloadUrl: ''
+            });
+        }   
+
         return files;
     } catch (error) {
         console.error('Error fetching data:', error);

--- a/web/flash/mlrs.js
+++ b/web/flash/mlrs.js
@@ -12,7 +12,7 @@ async function getDevices() {
 
         return data;
     } catch (error) {
-        console.error('Error fetching data:', error);
+        console.error('getDevices(): Error fetching data:', error);
         return [];
     }
 }
@@ -90,8 +90,11 @@ async function getVersions() {
 
         return data;
     } catch (error) {
-        console.error('Error fetching data:', error);
-        return [];
+        console.error('getVersions(): Error fetching data:', error);
+        return [{
+            versionStr: 'sorry, error downloading',
+            gitUrl: ''
+        }];
     }
 }
 
@@ -130,7 +133,11 @@ async function getFilesFromTree(device, url) {
 
         return files;
     } catch (error) {
-        console.error('Error fetching data:', error);
-        return [];
+        console.error('getFilesFromTree(): Error fetching data:', error);
+        return [{
+            name: 'sorry, error downloading',
+            extension: '',
+            downloadUrl: ''
+        }];
     }
 }

--- a/web/flash/mlrs.js
+++ b/web/flash/mlrs.js
@@ -78,10 +78,13 @@ async function getVersions() {
 
         // firmware_filename looks like pre-release-stm32/rx-E77-MBLKit-wle5cc-400-tcxo-v1.3.01-@ae667b78.hex
         // regex to get version and commit
-        var res = firmware_filename.split('.').slice(0, -1).join('.'); // remove extension
-        res = res.split('-').slice(-2).join('-'); // extract version part
+        //var res = firmware_filename.split('.').slice(0, -1).join('.'); // remove extension
+        //res = res.split('-').slice(-2).join('-'); // extract version part
+        // regex to get version and commit
+		var res = firmware_filename.match(/-(v\d\.\d+?\.\d+?-@.+?)\./)[1];
+        console.log(res);
 
-        // we could check if that is a dev version by odd pathc number, but let's believe that's the case
+        // we could check if that is a dev version by checking for odd patch number, but let's believe that's the case
 
         data[res] = {
             versionStr: res + ' (dev)',

--- a/web/flash/mlrs.js
+++ b/web/flash/mlrs.js
@@ -25,8 +25,8 @@ async function getVersions() {
         const response = await fetch(url);
         const data = await response.json();
 
-        //console.log(response);
-        //console.log(data);
+        //console.log('response',response);
+        //console.log('data',data);
 
         //console.log('-----');
         Object.keys(data).forEach(key => {
@@ -55,6 +55,8 @@ async function getVersions() {
         const response_main = await fetch(url_main);
         const data_main = await response_main.json();
 
+        //console.log('data_main',data_main);
+
         const firmware_url = data_main.tree
         .filter(item => item.type == 'tree')
         .filter(item => item.path == 'firmware');
@@ -66,9 +68,13 @@ async function getVersions() {
         const response_firmware = await fetch(firmware_url[0].url + '?recursive=true');
         const data_firmware = await response_firmware.json();
 
+        //console.log('data_firmware',data_firmware);
+
         const firmware_files = data_firmware.tree
         .filter(item => item.type == 'blob')
         .filter(item => item.path.includes('-stm32'))
+
+        //console.log('firmware_files',firmware_files);
 
         if (firmware_files.length == 0) {
             return data; // argh, something is wrong
@@ -76,18 +82,22 @@ async function getVersions() {
 
         const firmware_filename = firmware_files[0].path;
 
+        //console.log('firmware_filename',firmware_filename);
+
         // firmware_filename looks like pre-release-stm32/rx-E77-MBLKit-wle5cc-400-tcxo-v1.3.01-@ae667b78.hex
         // regex to get version and commit
         //var res = firmware_filename.split('.').slice(0, -1).join('.'); // remove extension
         //res = res.split('-').slice(-2).join('-'); // extract version part
         // regex to get version and commit
-		var res = firmware_filename.match(/-(v\d\.\d+?\.\d+?-@.+?)\./)[1];
-        console.log(res);
+        var res = firmware_filename.match(/-(v\d\.\d+?\.\d+?-@.+?)\./);
+        //console.log(res);
 
-        // we could check if that is a dev version by checking for odd patch number, but let's believe that's the case
+        if (!res) {
+            return data; // probably not a dev but a pre-relase version, should we also check for odd patch?
+        }
 
         data[res] = {
-            versionStr: res + ' (dev)',
+            versionStr: res[1] + ' (dev)',
             gitUrl: url_main + '?recursive=true'
         };
 


### PR DESCRIPTION
this PR
- adds a device selector, which makes the firmware lists really shorter and better comprehendable
- adds the type of release to the version number, like v1.3.00 (release)

I guess it would be nice if the Device and Version slectors could be in one line, to be more comptact, but I couldn't figure out how that would work. Might also be that you and others prefer it arranged like is.

I wonder if one always only should show the latest version of each type, relase, pre-release, dev

as before, for a quick look you can check www.olliw.eu/mlrs/flash
